### PR TITLE
Fix issue with to_xml printing xml to stdout.

### DIFF
--- a/lib/sosjobdsl.rb
+++ b/lib/sosjobdsl.rb
@@ -182,7 +182,7 @@ module Sosjobdsl
         }
       end  
 
-      puts builder.to_xml
+      return builder.to_xml
     end
 
     private


### PR DESCRIPTION
The to_xml function should return the xml of the object instead of printing to screen.
